### PR TITLE
Fix critical bugs in database, command, deploy, logs, and daemon commands

### DIFF
--- a/app/Commands/CommandCommand.php
+++ b/app/Commands/CommandCommand.php
@@ -46,8 +46,10 @@ class CommandCommand extends Command
         do {
             $this->time->sleep(1);
 
-            /** @var \Laravel\Forge\Resources\SiteCommand $command */
+            /** @var \Laravel\Forge\Resources\SiteCommand|null $command */
             $command = collect($this->forge->getSiteCommand($server->id, $siteId, $command->id))->first();
+
+            abort_if(is_null($command), 1, 'The command could not be found.');
         } while ($command->status == 'waiting');
 
         $this->step('Running');
@@ -57,9 +59,11 @@ class CommandCommand extends Command
         $username = $this->forge->site($server->id, $siteId)->username;
 
         $this->displayEventOutput($username, $eventId, function () use ($server, $siteId, &$command) {
+            /** @var \Laravel\Forge\Resources\SiteCommand|null $command */
             $command = collect($this->forge->getSiteCommand($server->id, $siteId, $command->id))->first();
 
-            /** @var \Laravel\Forge\Resources\SiteCommand $command */
+            abort_if(is_null($command), 1, 'The command could not be found.');
+
             return $command->status == 'running';
         });
 

--- a/app/Commands/Concerns/InteractsWithLogs.php
+++ b/app/Commands/Concerns/InteractsWithLogs.php
@@ -50,7 +50,7 @@ trait InteractsWithLogs
         $sitePath = '/home/'.$site->username.'/'.$site->name;
 
         $sitePath = basename($sitePath) == 'current'
-            ? basename($sitePath)
+            ? dirname($sitePath)
             : $sitePath;
 
         $this->showRemoteLogs(collect($files)->map(function ($file) use ($sitePath) {

--- a/app/Commands/DaemonLogsCommand.php
+++ b/app/Commands/DaemonLogsCommand.php
@@ -12,7 +12,7 @@ class DaemonLogsCommand extends Command
      * @var string
      */
     protected $signature = 'daemon:logs {daemon? : The daemon ID}
-    `                                   {--f|follow : Monitor the log changes in realtime}';
+                                        {--f|follow : Monitor the log changes in realtime}';
 
     /**
      * The description of the command.

--- a/app/Commands/DatabaseLogsCommand.php
+++ b/app/Commands/DatabaseLogsCommand.php
@@ -32,7 +32,7 @@ class DatabaseLogsCommand extends Command
         // @phpstan-ignore-next-line
         $databaseType = $this->currentServer()->databaseType;
 
-        if (! in_array($databaseType, ['mysql', 'mysql8', 'postgres'])) {
+        if (! in_array($databaseType, ['mysql', 'mysql8', 'mariadb', 'postgres', 'postgres13'])) {
             abort(1, 'Retrieving logs from ['.$databaseType.'] databases is not supported.');
         }
 

--- a/app/Commands/DeployLogsCommand.php
+++ b/app/Commands/DeployLogsCommand.php
@@ -31,10 +31,12 @@ class DeployLogsCommand extends Command
 
         $this->step('Retrieving the latest deployment logs');
 
-        $lastDeploymentId = optional(collect($this->forge->siteDeployments(
+        $lastDeployment = collect($this->forge->siteDeployments(
             $this->currentServer()->id,
             $siteId,
-        ))->first())['id'];
+        ))->first();
+
+        $lastDeploymentId = $lastDeployment ? $lastDeployment['id'] : null;
 
         abort_if(is_null($lastDeploymentId), 1, 'This site has not been deployed.');
 


### PR DESCRIPTION
## Summary
- Add `mariadb` and `postgres13` to `DatabaseLogsCommand` type check to match other database commands (fixes #1)
- Add null safety checks for `getSiteCommand()` return value in `CommandCommand` to prevent null reference errors (fixes #2)
- Fix broken `optional()` array access in `DeployLogsCommand` by splitting into proper null check (fixes #3)
- Fix `InteractsWithLogs` path logic to use `dirname()` instead of `basename()` when stripping `/current` symlink (fixes #4)
- Remove stray backtick character in `DaemonLogsCommand` signature that corrupts the `--follow` option (fixes #5)

## Test plan
- [ ] Verify `database:logs` works with MariaDB and PostgreSQL 13 servers
- [ ] Verify `command` handles empty API responses gracefully
- [ ] Verify `deploy:logs` works when no deployments exist (shows proper error)
- [ ] Verify site logs resolve correct path for sites using `/current` symlink
- [ ] Verify `daemon:logs --follow` option is recognized correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)